### PR TITLE
Support for DD_TRACE_AGENT_URL env config

### DIFF
--- a/src/DDTrace/Integrations/Lumen/V5/LumenIntegrationLoader.php
+++ b/src/DDTrace/Integrations/Lumen/V5/LumenIntegrationLoader.php
@@ -66,6 +66,10 @@ final class LumenIntegrationLoader
 
         // Trace middleware
         $traceMiddleware = function ($middlewares) {
+            if (!is_array($middlewares)) {
+                $middlewares = [ $middlewares ];
+            }
+
             foreach ($middlewares as $middleware) {
                 // Ignore closures
                 if ($middleware instanceof \Closure) {

--- a/src/DDTrace/Transport/Http.php
+++ b/src/DDTrace/Transport/Http.php
@@ -17,6 +17,8 @@ final class Http implements Transport
 
     // Env variables to configure trace agent. They will be moved to a configuration class once we implement it.
     const AGENT_HOST_ENV = 'DD_AGENT_HOST';
+    const TRACE_AGENT_URL_ENV = 'DD_TRACE_AGENT_URL';
+
     // The Agent has a payload cap of 10MB
     // https://github.com/DataDog/datadog-agent/blob/355a34d610bd1554572d7733454ac4af3acd89cd/pkg/trace/api/api.go#L31
     const AGENT_REQUEST_BODY_LIMIT = 10485760; // 10 * 1024 * 1024 => 10MB
@@ -75,8 +77,10 @@ final class Http implements Transport
     {
         $host = getenv(self::AGENT_HOST_ENV) ?: self::DEFAULT_AGENT_HOST;
         $port = getenv(self::TRACE_AGENT_PORT_ENV) ?: self::DEFAULT_TRACE_AGENT_PORT;
+        $traceAgentUrl = getenv(self::TRACE_AGENT_URL_ENV) ?: "http://${host}:${port}";
         $path = self::DEFAULT_TRACE_AGENT_PATH;
-        $endpoint = "http://${host}:${port}${path}";
+        $endpoint = "${traceAgentUrl}${path}";
+
 
         $this->config = array_merge([
             'endpoint' => $endpoint,

--- a/src/ext/coms.c
+++ b/src/ext/coms.c
@@ -607,7 +607,8 @@ static ddtrace_coms_stack_t *_dd_coms_attempt_acquire_stack(void) {
     return stack;
 }
 
-#define HOST_FORMAT_STR "http://%s:%u/v0.4/traces"
+#define TRACE_PATH_STR "/v0.4/traces"
+#define HOST_FORMAT_STR "http://%s:%u" TRACE_PATH_STR
 
 atomic_uintptr_t memoized_agent_curl_headers;
 
@@ -637,6 +638,21 @@ static void _dd_curl_set_hostname(CURL *curl) {
     int64_t port = get_dd_trace_agent_port();
     if (port <= 0 || port > 65535) {
         port = 8126;
+    }
+
+    char *url = get_dd_trace_agent_url();
+    if (url && url[0]) {
+        size_t agent_url_len = strlen(url) + sizeof(TRACE_PATH_STR);
+        char *agent_url = malloc(agent_url_len);
+        sprintf(agent_url, "%s%s", url, TRACE_PATH_STR);
+        curl_easy_setopt(curl, CURLOPT_URL, agent_url);
+        char *message = malloc(16 + strlen(agent_url));
+        sprintf(message, "Send request to %s", agent_url);
+        ddtrace_log_debug(message);
+        free(url);
+        free(hostname);
+        free(agent_url);
+        return;
     }
 
     if (hostname) {

--- a/src/ext/configuration.h
+++ b/src/ext/configuration.h
@@ -44,6 +44,7 @@ void ddtrace_config_shutdown(void);
     CHAR(get_dd_agent_host, "DD_AGENT_HOST", "localhost")                                                            \
     CHAR(get_dd_dogstatsd_port, "DD_DOGSTATSD_PORT", "8125")                                                         \
     INT(get_dd_trace_agent_port, "DD_TRACE_AGENT_PORT", 8126)                                                        \
+    CHAR(get_dd_trace_agent_url, "DD_TRACE_AGENT_URL", "")                                                           \
     BOOL(get_dd_trace_measure_compile_time, "DD_TRACE_MEASURE_COMPILE_TIME", true)                                   \
     BOOL(get_dd_trace_debug, "DD_TRACE_DEBUG", false)                                                                \
     BOOL(get_dd_trace_heath_metrics_enabled, "DD_TRACE_HEALTH_METRICS_ENABLED", false)                               \


### PR DESCRIPTION
### Description

Currently agent url http scheme is hardcoded to `http://` there is no way for me to set it to `https://`.
On other language library, dd-trace-js and dd-trace-dotnet does support  DD_TRACE_AGENT_URL to set agent url, not just DD_AGENT_HOST and DD_AGENT_PORT as in php.

So this commit would add support for env configuration DD_TRACE_AGENT_URL to support custom agent trace url.

### Readiness checklist
- [ ] (only for Members) Changelog has been added to the appropriate release draft. Create one if necessary.
- [ ] Tests added for this feature/bug.

### Reviewer checklist
- [ ] Appropriate labels assigned.
- [ ] Milestone is set.
- [ ] Changelog has been added to the appropriate release draft. For community contributors the reviewer is in charge of this task.
